### PR TITLE
Change to css transform which seems to be better supported than sideways

### DIFF
--- a/src/components/CareerFramework.vue
+++ b/src/components/CareerFramework.vue
@@ -79,7 +79,7 @@ table {
 }
 .category {
   padding: 0px 15px;
-  writing-mode: sideways-lr;
+  transform: rotate(-90deg);
 }
 .level {
   padding: 10px;


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation, it looks like "sideways" is only compatible with Firefox.